### PR TITLE
hosted: fix infinite loop in DMI read/write retry logic

### DIFF
--- a/blackmagic_addon/hosted/remote_rv_protocol.c
+++ b/blackmagic_addon/hosted/remote_rv_protocol.c
@@ -66,6 +66,7 @@ bool remote_ch32_riscv_dmi_read(riscv_dmi_s *dmi, uint32_t address, uint32_t *va
             dmi->fault = RV_DMI_SUCCESS;
             return true;
         }
+        retries--;
     }
 }
 /**
@@ -93,6 +94,7 @@ bool remote_ch32_riscv_dmi_write(riscv_dmi_s *dmi, uint32_t address, uint32_t va
             dmi->fault = RV_DMI_SUCCESS;
             return true;
         }
+        retries--;
     }
 }
 /**


### PR DESCRIPTION
## Summary
- Add missing \`retries--\` in \`remote_ch32_riscv_dmi_read()\` and \`remote_ch32_riscv_dmi_write()\`
- Both functions declare \`int retries = 10\` and check \`if (!retries)\` but never decrement the counter, causing an infinite hang if the underlying \`_rs\` call returns false

## Impact
When a RISC-V DMI transaction fails (e.g. target not responding, bus error), the probe locks up permanently instead of failing gracefully after 10 attempts. Requires a power cycle to recover.

## Fix
One line each — \`retries--;\` after the failed attempt, before looping back.